### PR TITLE
fix border position calculations

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -49,8 +49,18 @@ const newYork1 = { label: 'new york', lat: 40.7084, lng: -74.0176, zoom: 3 };
 const newYork2 = { ...newYork1, zoom: 7 };
 const philadelphia = { label: 'philadelphia', lat: 39.9417, lng: -75.1571, zoom: 13 };
 const tokyo = { label: 'Tōkyō', lat: 35.689, lng: 139.692, zoom: 8 };
+const berlin = { label: 'Berlin', lat: 52.52, lng: 13.405, zoom: 8 };
 
-const places = [stuttgart1, pforzheim, germersheim, frankfurt1, newYork1, philadelphia, tokyo];
+const places = [
+  stuttgart1,
+  pforzheim,
+  germersheim,
+  frankfurt1,
+  newYork1,
+  philadelphia,
+  tokyo,
+  berlin,
+];
 
 // intermediate transitions
 const zoomOutStuttgart = createTransitionFunction(
@@ -289,7 +299,7 @@ function checkVisibility(evt, frame) {
       ctx.stroke();
     } else {
       // draw an arrow at the edge (y is down)
-      const { x, y, direction } = frame.borderPosition(place);
+      const { x, y, direction, border } = frame.borderPosition(place);
 
       const arrowSize = 15;
       const x1 = x + arrowSize * Math.cos(direction + Math.PI + Math.PI / 8);
@@ -308,7 +318,11 @@ function checkVisibility(evt, frame) {
 
       // arrow segment, testing offset feature
       const arrowSegmentLength = 20 + arrowSize;
-      const { x: segmentX, y: segmentY } = frame.borderPosition(place, arrowSegmentLength);
+      const {
+        x: segmentX,
+        y: segmentY,
+        border: borderArrow,
+      } = frame.borderPosition(place, arrowSegmentLength);
       const startX = x + (arrowSize - 3) * Math.cos(direction + Math.PI);
       const startY = y + (arrowSize - 3) * Math.sin(direction + Math.PI);
 
@@ -319,6 +333,25 @@ function checkVisibility(evt, frame) {
       ctx.moveTo(startX, startY);
       ctx.lineTo(segmentX, segmentY);
       ctx.stroke();
+
+      // simulate inset maps with an offset of arrowSegmentLength, check that
+      // they are placed on the correct border
+      const colors = {
+        top: 'firebrick',
+        bottom: 'forestgreen',
+        left: 'rebeccapurple',
+        right: 'steelblue',
+      };
+
+      ctx.beginPath();
+      ctx.strokeStyle = colors[borderArrow];
+      ctx.lineWidth = 2;
+      ctx.strokeRect(
+        segmentX - arrowSegmentLength,
+        segmentY - arrowSegmentLength,
+        2 * arrowSegmentLength,
+        2 * arrowSegmentLength,
+      );
     }
   });
   ctx.restore();

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -153,10 +153,16 @@ export default class Frame {
 
     /*
      * We want to calculate the intersection of the ray from the frame center
-     * in the direction of the position with the frame border. So here, we need
-     * the actual canvas size and ignore the offset.
+     * in the direction of the position with the frame border, inset by
+     * `offset` in every direction. To determine which border the ray
+     * intersects with, we need to calculate the direction to one corner of the
+     * inset frame border from the center of the frame. Because the inset is
+     * constant on all sides, the aspect ratio might be different than that of
+     * the frame itself.
      */
-    const aspectDir = Math.atan2(this.canvasSize.x, this.canvasSize.y);
+    const aspectDir = Math.atan2(height, width);
+
+    // direction from center
     const dir = Math.atan2(point.y - this.canvasSize.y / 2, point.x - this.canvasSize.x / 2);
 
     let x: number;


### PR DESCRIPTION
For one, this fixes a bug where the x and y direction of the aspect ratio calculation were switched, leading to incorrect placement near the corners of the frame. When using offsets from the actual frame border, the aspect ratio of the offset border is now used for correct behavior in this case.

re #13